### PR TITLE
fix(helpers): `ui.py` not using correct paths, missing helpers, split flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,23 +1,57 @@
 {
   "nodes": {
-    "dzgui": {
+    "a2s": {
       "flake": false,
       "locked": {
-        "lastModified": 1731285317,
-        "narHash": "sha256-x5GSyrbEZoru5p70QVRSFx52Njkhvtg/+qc94MqpOmo=",
+        "lastModified": 1679346231,
+        "narHash": "sha256-cbXqDeVfAJyk5PeZWBSmi6G4ynYC3L34LFofKPdlwGo=",
+        "owner": "yepoleb",
+        "repo": "python-a2s",
+        "rev": "c7590ffa9a6d0c6912e17ceeab15b832a1090640",
+        "type": "github"
+      },
+      "original": {
+        "owner": "yepoleb",
+        "repo": "python-a2s",
+        "rev": "c7590ffa9a6d0c6912e17ceeab15b832a1090640",
+        "type": "github"
+      }
+    },
+    "dayzquery": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1730587383,
+        "narHash": "sha256-oKzruS+5f3goXmqS4Oy7XIKcv8GZ1SavmHI1+XC9rVA=",
         "owner": "aclist",
-        "repo": "dztui",
-        "rev": "bae6a57e1ee5660a07e3a3c326ec68617b831d31",
+        "repo": "dayzquery",
+        "rev": "3088bbfb147b77bc7b6a9425581b439889ff3f7f",
         "type": "github"
       },
       "original": {
         "owner": "aclist",
-        "ref": "main",
+        "repo": "dayzquery",
+        "rev": "3088bbfb147b77bc7b6a9425581b439889ff3f7f",
+        "type": "github"
+      }
+    },
+    "dzguiSrc": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1731284526,
+        "narHash": "sha256-x5GSyrbEZoru5p70QVRSFx52Njkhvtg/+qc94MqpOmo=",
+        "owner": "aclist",
+        "repo": "dztui",
+        "rev": "3bdc0057a2d41e0a633f110a95a41e897f00e2cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "aclist",
+        "ref": "dzgui",
         "repo": "dztui",
         "type": "github"
       }
     },
-    "dzgui-testing": {
+    "dzguiSrc-testing": {
       "flake": false,
       "locked": {
         "lastModified": 1732201127,
@@ -52,8 +86,10 @@
     },
     "root": {
       "inputs": {
-        "dzgui": "dzgui",
-        "dzgui-testing": "dzgui-testing",
+        "a2s": "a2s",
+        "dayzquery": "dayzquery",
+        "dzguiSrc": "dzguiSrc",
+        "dzguiSrc-testing": "dzguiSrc-testing",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,121 @@
+{
+  a2s-src,
+  dayzquery-src,
+  dzguiName,
+  dzgui-src,
+  dzguiBranch,
+  patchVer,
+  dzguiPostInstall,
+  lib,
+  stdenv,
+  makeWrapper,
+  wrapGAppsHook,
+  curl,
+  gtk3,
+  gobject-introspection,
+  inetutils,
+  jq,
+  python311,
+  wmctrl,
+  xdotool,
+  zenity,
+}:
+stdenv.mkDerivation rec {
+  pname = dzguiName;
+  # Get src and version from the flake
+  # This makes `nix flake update dzgui` work for easier updating
+  src = dzgui-src + "/"; # Flake input is a directory or archive
+  version = "${dzgui-src.rev}-${patchVer}";
+
+  buildInputs = [
+    curl
+    inetutils
+    jq
+    wmctrl
+    xdotool
+    zenity
+
+    # GUI
+    (python311.withPackages (ps: [ps.pygobject3]))
+  ];
+
+  nativeBuildInputs = [
+    makeWrapper
+    wrapGAppsHook
+    gobject-introspection
+  ];
+
+  patches = [
+    # ./patches/main/disable_self_management.patch
+    # ./patches/main/disable_branch_switch.patch
+    # ./patches/main/fix_ping.patch
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    mkdir -p $out/opt
+
+    cp -r {dzgui.sh,helpers,images,CHANGELOG.md} $out/opt
+    cp images/{dzgui,grid.png,hero.png,icon.png,logo.png} $out/opt
+    mkdir -p $out/opt/helpers/a2s
+    cp ${a2s-src}/a2s/* $out/opt/helpers/a2s
+    cp ${dayzquery-src}/dayzquery.py $out/opt/helpers/a2s
+
+    for i in 16 24 48 64 96 128 256; do
+      mkdir -p $out/share/icons/hicolor/''${i}x''${i}/apps
+      cp images/icons/''${i}.png $out/share/icons/hicolor/''${i}x''${i}/apps/dzgui.png
+    done
+
+    mkdir -p $out/share/applications
+    cat << EOF >> $out/share/applications/${pname}.desktop
+    [Desktop Entry]
+    Version=1.0
+    Type=Application
+    Terminal=false
+    Exec=$out/bin/dzgui
+    Name=$pname
+    Comment=DayZ GUI server browser and frontend for Linux
+    Icon=dzgui
+    Categories=Game
+    EOF
+
+    substituteInPlace $out/opt/dzgui.sh \
+      --replace-fail 'ping -c1 -4' 'ping -c1' \
+      --replace-fail 'for dir in "$state_path" "$cache_path" "$share_path" "$helpers_path" "$freedesktop_path" "$config_path" "$log_path"; do' \
+        'for dir in "$state_path" "$cache_path" "$config_path" "$log_path"; do' \
+      --replace-fail '[[ ! -f $share_path/icon.png ]] && freedesktop_dirs' "" \
+      --replace-fail '[[ ! -f "$freedesktop_path/$app_name.desktop" ]] && freedesktop_dirs' "" \
+      --replace-fail "    check_version" "" \
+      --replace-fail 'fetch_helpers > >(pdialog "Checking helper files")' "" \
+      --replace-fail 'source "$config_file"' "source ''\"\$config_file''\"''\nbranch=${dzguiBranch}" \
+      --replace-fail '#CONSTANTS' "#CONSTANTS''\nbranch=${dzguiBranch}" \
+      --replace-fail '="/usr/bin/zenity"' =${zenity}/bin/zenity \
+      --replace-fail '="$HOME/.local/share/$app_name"' "=$out/opt" \
+      --replace-fail '="$share_path/dzgui.sh"' "=$out/opt/dzgui.sh" \
+      --replace-fail '="$share_path/helpers"' "=$out/opt/helpers"
+
+    substituteInPlace $out/opt/helpers/funcs \
+      --replace-fail '="/usr/bin/zenity"' =${zenity}/bin/zenity \
+      --replace-fail '="$HOME/.local/share/$app_name"' =$out/opt
+
+    substituteInPlace $out/opt/helpers/lan \
+      --replace-fail '="$HOME/.local/share/dzgui/helpers/query_v2.py"' =$out/opt/helpers/query_v2.py
+
+    substituteInPlace $out/opt/helpers/ui.py \
+      --replace-fail "= '%s/.local/share/dzgui/helpers' %(user_path)" "= \"$out/opt/helpers\"" \
+      --replace-fail "= '%s/CHANGELOG.md' %(state_path)" "= \"$out/opt/CHANGELOG.md\""
+
+    ln -s $out/opt/dzgui.sh $out/bin/dzgui
+
+    runHook postInstall
+  '';
+
+  postInstall = dzguiPostInstall;
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix PATH ':' ${lib.makeBinPath buildInputs}
+    )
+  '';
+}


### PR DESCRIPTION
- Added missing helpers (`a2s` and `dayzquery`)
- Package is now in `package.nix` with some extra arguments for better reuseability
- Fixed `ui.py` sourcing from ``~/.local/share/dzgui/helpers`