### PR TITLE
fix(ci/update): Remove myself from the reviewers

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -19,7 +19,6 @@ jobs:
           token: ${{ secrets.GH_TOKEN_FOR_UPDATES }}
           pr-title: "Update flake.lock"
           pr-assignees: jiriks74
-          pr-reviewers: jiriks74
           pr-labels: |
             flake.lock
             automated


### PR DESCRIPTION
Since a GitHub token is used to make the pull request I'm the author of it. This means that I cannot be the reviewer - you cannot request a review from the author.

It resulted in the following error when running
the update action:

```
Error: Review cannot be requested from pull request author.
```